### PR TITLE
Fix Git URL parameters

### DIFF
--- a/pipelines/task-git-checkout.yaml
+++ b/pipelines/task-git-checkout.yaml
@@ -4,12 +4,8 @@ metadata:
   name: git-checkout
 spec:
   params:
-    - name: gitOrganization
-      description: Git organization name
-    - name: gitRepository
-      description: Git source code repository name
-    - name: gitRepositoryManagerFQDN
-      description: Git host like github.com or bitbucket.org
+    - name: gitRepositoryUrl
+      description: Git source code repository url
     - name: gitRevision
       description: Git source revision
     - name: gitRepositoryDeleteExisting
@@ -58,7 +54,7 @@ spec:
           value: $(workspaces.shared.path)/source/$(params.gitCheckoutSubDirectory)
       args:
         - clone
-        - https://$(GIT_TOKEN)@$(params.gitRepositoryManagerFQDN)/$(params.gitOrganization)/$(params.gitRepository)
+        - https://$(GIT_TOKEN)@$(params.gitRepositoryUrl)
         - $(GIT_CHECKOUT_DIR)
       command:
         - /usr/bin/git

--- a/simple-api/.valuestream/pipelines/pipeline-deploy-simple-api.yaml
+++ b/simple-api/.valuestream/pipelines/pipeline-deploy-simple-api.yaml
@@ -4,12 +4,8 @@ metadata:
   name: rolling-upgrade-simple-api
 spec:
   params:
-    - name: gitRepositoryManagerFQDN
-      description: Git host like github.com or bitbucket.org
-    - name: gitOrganization
-      description: Git organization name
-    - name: gitRepository
-      description: Git source code repository name
+    - name: gitRepositoryUrl
+      description: Git source code repository url
     - name: gitRevision
       description: Git source revision
     - name: secretNameGitToken
@@ -36,12 +32,8 @@ spec:
         - name: shared
           workspace: shared
       params:
-        - name: gitOrganization
-          value: $(params.gitOrganization)
-        - name: gitRepository
-          value: $(params.gitRepository)
-        - name: gitRepositoryManagerFQDN
-          value: $(params.gitRepositoryManagerFQDN)
+        - name: gitRepositoryUrl
+          value: $(params.gitRepositoryUrl)
         - name: gitRevision
           value: $(params.gitRevision)
         - name: secretNameGitToken


### PR DESCRIPTION
Gitリポジトリの指定方法がownerやrepository nameを指定する方法からURLを指定する方法に変更されましたが、sample repositoryが追随されていませんでしたので、追随するように修正しました。